### PR TITLE
feat: 地図のMA選択を複数アクティブ対応し、詳細を右サイドパネルに表示

### DIFF
--- a/src/areacode/features/map/components/ActiveMAPanel.tsx
+++ b/src/areacode/features/map/components/ActiveMAPanel.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { MACompListContent } from 'areacode/pages/list/MACompListContent'
+import { MAAreaCodeInfoCards } from 'areacode/pages/list/components'
+import type { ActiveMAInfo } from '../types'
+
+const mapCardDisplayParam = [
+  '市外局番',
+  '番号領域',
+  '都道府県',
+  'MA名',
+  '市区町村',
+  '一部地域詳細表示',
+]
+
+const cityOptions = {
+  areaDisplayFull: true,
+  isQuiz: false,
+}
+
+export function ActiveMAPanel({
+  activeMAs,
+  onRemove,
+}: {
+  activeMAs: ActiveMAInfo[]
+  onRemove: (featureId: string | number) => void
+}) {
+  return (
+    <div
+      style={{
+        borderLeft: '1px solid #d1d5db',
+        background: '#f9fafb',
+        padding: 12,
+        overflowY: 'auto',
+      }}
+    >
+      <h2 style={{ margin: '4px 0 12px', fontSize: 18 }}>アクティブなMA</h2>
+      {activeMAs.length === 0 && (
+        <p style={{ margin: 0, color: '#4b5563' }}>
+          地図上のMAをクリックすると、ここに情報を表示します。
+        </p>
+      )}
+      {activeMAs.map((activeMA) => {
+        const { MAComps } = new MACompListContent().filter(
+          'MA',
+          activeMA.properties['_MA名'],
+        )
+        return (
+          <div
+            key={activeMA.featureId}
+            style={{
+              marginBottom: 12,
+              padding: 10,
+              border: '1px solid #e5e7eb',
+              borderRadius: 8,
+              backgroundColor: '#ffffff',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: 8,
+              }}
+            >
+              <strong>{activeMA.properties['_MA名']}</strong>
+              <button
+                type="button"
+                onClick={() => {
+                  onRemove(activeMA.featureId)
+                }}
+              >
+                ×
+              </button>
+            </div>
+            <MAAreaCodeInfoCards
+              MAComps={MAComps}
+              displayParam={mapCardDisplayParam}
+              cityOptions={cityOptions}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/areacode/features/map/components/MapLayers.tsx
+++ b/src/areacode/features/map/components/MapLayers.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import { Layer, Source } from 'react-map-gl/maplibre'
+import type { FeatureCollection, Geometry } from 'geojson'
+import {
+  activeMABorderStyle,
+  activeMAFillStyle,
+  digits2BorderStyle,
+  digits2LabelStyle,
+  maBorderStyle,
+  maFillStyle,
+  maLabelStyle,
+} from '../mapStyles'
+
+export function MapLayers({
+  maGeoData,
+  digits2GeoData,
+  activeMAFeatureCollection,
+  showMA,
+  showDigits2,
+}: {
+  maGeoData: FeatureCollection<Geometry>
+  digits2GeoData: FeatureCollection<Geometry>
+  activeMAFeatureCollection: FeatureCollection<Geometry>
+  showMA: boolean
+  showDigits2: boolean
+}) {
+  return (
+    <>
+      {maGeoData && (
+        <Source
+          id="ma-source"
+          type="geojson"
+          data={maGeoData}
+          generateId={true}
+        >
+          <Layer
+            {...maFillStyle}
+            layout={{ visibility: showMA ? 'visible' : 'none' }}
+          ></Layer>
+          <Layer
+            {...maBorderStyle}
+            layout={{ visibility: showMA ? 'visible' : 'none' }}
+          ></Layer>
+          <Layer
+            {...maLabelStyle}
+            layout={{
+              ...maLabelStyle.layout,
+              visibility: showMA ? 'visible' : 'none',
+            }}
+          ></Layer>
+        </Source>
+      )}
+
+      {digits2GeoData && (
+        <Source
+          id="digits2-source"
+          type="geojson"
+          data={digits2GeoData}
+          generateId={true}
+        >
+          <Layer
+            {...digits2BorderStyle}
+            layout={{ visibility: showDigits2 ? 'visible' : 'none' }}
+          ></Layer>
+          <Layer
+            {...digits2LabelStyle}
+            layout={{
+              ...digits2LabelStyle.layout,
+              visibility: showDigits2 ? 'visible' : 'none',
+            }}
+          ></Layer>
+        </Source>
+      )}
+
+      <Source
+        id="active-ma-source"
+        type="geojson"
+        data={activeMAFeatureCollection}
+      >
+        <Layer
+          {...activeMAFillStyle}
+          layout={{ visibility: showMA ? 'visible' : 'none' }}
+        ></Layer>
+        <Layer
+          {...activeMABorderStyle}
+          layout={{ visibility: showMA ? 'visible' : 'none' }}
+        ></Layer>
+      </Source>
+    </>
+  )
+}

--- a/src/areacode/features/map/hooks/useMapGeoData.ts
+++ b/src/areacode/features/map/hooks/useMapGeoData.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react'
+import * as topojson from 'topojson-client'
+import type { Feature, FeatureCollection, Geometry } from 'geojson'
+import { getColorStyleByAreaCode } from 'areacode/components'
+import { EMPTY_FEATURE_COLLECTION } from '../types'
+
+export function useMapGeoData() {
+  const [maGeoData, setMaGeoData] = useState<FeatureCollection<Geometry>>(
+    EMPTY_FEATURE_COLLECTION,
+  )
+  const [digits2GeoData, setDigits2GeoData] = useState<
+    FeatureCollection<Geometry>
+  >(EMPTY_FEATURE_COLLECTION)
+
+  useEffect(() => {
+    fetch('/map/areacode.json')
+      .then((res) => res.json())
+      .then((topoData) => {
+        const geojson = topojson.feature(
+          topoData,
+          topoData.objects.areacode,
+        ) as unknown as FeatureCollection<Geometry>
+        geojson.features = geojson.features.map((f: Feature<Geometry>) => {
+          const properties = (f.properties ?? {}) as Record<string, string>
+          return {
+            ...f,
+            properties: {
+              ...properties,
+              fillColor: getColorStyleByAreaCode(`0${properties['_市外局番']}`)
+                .background.backgroundColor,
+            },
+          }
+        })
+        setMaGeoData(geojson)
+      })
+  }, [])
+
+  useEffect(() => {
+    fetch('/map/digits2.json')
+      .then((res) => res.json())
+      .then((topoData) => {
+        const geojson = topojson.feature(
+          topoData,
+          topoData.objects['2digits'],
+        ) as unknown as FeatureCollection<Geometry>
+        geojson.features = geojson.features.map((f: Feature<Geometry>) => {
+          const properties = (f.properties ?? {}) as Record<string, string>
+          return {
+            ...f,
+            properties: {
+              ...properties,
+              fillColor: getColorStyleByAreaCode(`0${properties['_市外局番']}`)
+                .background.backgroundColor,
+            },
+          }
+        })
+        setDigits2GeoData(geojson)
+      })
+  }, [])
+
+  return {
+    maGeoData,
+    digits2GeoData,
+  }
+}

--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import Map, {
   Source,
   Layer,
-  Popup,
   FillLayerSpecification,
 } from 'react-map-gl/maplibre'
 import type {
@@ -21,15 +20,14 @@ import { getColorStyleByAreaCode } from 'areacode/components'
 const MA_MAP_STYLE =
   'https://tile.openstreetmap.jp/styles/osm-bright-ja/style.json'
 
-type PopupInfoType = {
-  longitude: number
-  latitude: number
-  properties: Record<string, string>
-}
-
 type HoverState = {
   sourceId: 'ma-source' | 'digits2-source'
   featureId: string | number
+}
+
+type ActiveMAInfo = {
+  featureId: string | number
+  properties: Record<string, string>
 }
 
 const EMPTY_FEATURE_COLLECTION: FeatureCollection<Geometry> = {
@@ -47,10 +45,10 @@ function App() {
   const [showMA, setShowMA] = useState(true)
   const [showDigits2, setShowDigits2] = useState(true)
 
-  const [popupInfo, setPopupInfo] = useState<PopupInfoType | null>(null)
   const mapRef = useRef<MapLibreMap | null>(null)
 
   const hoverRef = useRef<HoverState | null>(null)
+  const [activeMAs, setActiveMAs] = useState<ActiveMAInfo[]>([])
 
   useEffect(() => {
     fetch('/map/areacode.json')
@@ -113,16 +111,32 @@ function App() {
   }, [])
 
   const onClick = useCallback((event: MapLayerMouseEvent) => {
+    mapRef.current = event.target
     const feature = event.features?.[0]
-    if (!feature || feature.source !== 'ma-source' || !feature.properties) {
-      setPopupInfo(null)
+    if (
+      !feature ||
+      feature.source !== 'ma-source' ||
+      !feature.properties ||
+      feature.id === undefined
+    ) {
       return
     }
 
-    setPopupInfo({
-      longitude: event.lngLat.lng,
-      latitude: event.lngLat.lat,
-      properties: feature.properties as Record<string, string>,
+    const featureId = feature.id
+    const properties = feature.properties as Record<string, string>
+
+    setActiveMAs((prev) => {
+      const alreadyActive = prev.some((ma) => ma.featureId === featureId)
+      event.target.setFeatureState(
+        { source: 'ma-source', id: featureId },
+        { active: !alreadyActive },
+      )
+
+      if (alreadyActive) {
+        return prev.filter((ma) => ma.featureId !== featureId)
+      }
+
+      return [...prev, { featureId, properties }]
     })
   }, [])
 
@@ -169,6 +183,8 @@ function App() {
       'fill-outline-color': ['get', 'fillColor'],
       'fill-opacity': [
         'case',
+        ['boolean', ['feature-state', 'active'], false],
+        1,
         ['boolean', ['feature-state', 'hover'], false],
         0.55,
         0.85,
@@ -184,6 +200,18 @@ function App() {
       'line-color': '#1a1a1a',
       'line-width': ['interpolate', ['linear'], ['zoom'], 4, 0.4, 8, 1.2],
       'line-opacity': 0.7,
+    },
+  }
+
+  const maActiveBorderStyle: LineLayerSpecification = {
+    source: 'ma-source',
+    id: 'ma-active-borders',
+    type: 'line',
+    filter: ['boolean', ['feature-state', 'active'], false],
+    paint: {
+      'line-color': '#ef4444',
+      'line-width': ['interpolate', ['linear'], ['zoom'], 4, 1.4, 8, 3],
+      'line-opacity': 0.95,
     },
   }
 
@@ -241,109 +269,7 @@ function App() {
     ...(showDigits2 ? ['digits2-fills'] : []),
   ]
 
-  return (
-    <div style={{ position: 'relative', width: '100vw', height: '100vh' }}>
-      <div
-        style={{
-          position: 'absolute',
-          zIndex: 1,
-          top: 12,
-          left: 12,
-          padding: '8px 12px',
-          backgroundColor: 'rgba(255,255,255,0.9)',
-          borderRadius: 8,
-          boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-          fontSize: 14,
-        }}
-      >
-        <label style={{ display: 'block', marginBottom: 4 }}>
-          <input
-            type="checkbox"
-            checked={showMA}
-            onChange={(event) => setShowMA(event.target.checked)}
-          />{' '}
-          MA地図
-        </label>
-        <label style={{ display: 'block' }}>
-          <input
-            type="checkbox"
-            checked={showDigits2}
-            onChange={(event) => setShowDigits2(event.target.checked)}
-          />{' '}
-          市外局番2桁地図
-        </label>
-      </div>
-      <Map
-        initialViewState={{
-          longitude: 139.76711,
-          latitude: 35.68074,
-          zoom: 6,
-        }}
-        style={{ position: 'absolute', top: 0, bottom: 0, width: '100%' }}
-        mapStyle={MA_MAP_STYLE}
-        onClick={onClick}
-        onMouseMove={onHover}
-        onMouseLeave={clearHoverState}
-        interactiveLayerIds={interactiveLayerIds}
-      >
-        {maGeoData && (
-          <Source
-            id="ma-source"
-            type="geojson"
-            data={maGeoData}
-            generateId={true}
-          >
-            <Layer
-              {...maFillStyle}
-              layout={{ visibility: showMA ? 'visible' : 'none' }}
-            ></Layer>
-            <Layer
-              {...maBorderStyle}
-              layout={{ visibility: showMA ? 'visible' : 'none' }}
-            ></Layer>
-            <Layer
-              {...maLabelStyle}
-              layout={{
-                ...maLabelStyle.layout,
-                visibility: showMA ? 'visible' : 'none',
-              }}
-            ></Layer>
-          </Source>
-        )}
-        {digits2GeoData && (
-          <Source
-            id="digits2-source"
-            type="geojson"
-            data={digits2GeoData}
-            generateId={true}
-          >
-            <Layer
-              {...digits2BorderStyle}
-              layout={{ visibility: showDigits2 ? 'visible' : 'none' }}
-            ></Layer>
-            <Layer
-              {...digits2LabelStyle}
-              layout={{
-                ...digits2LabelStyle.layout,
-                visibility: showDigits2 ? 'visible' : 'none',
-              }}
-            ></Layer>
-          </Source>
-        )}
-        {popupInfo && <PopupInfo info={popupInfo} setFunc={setPopupInfo} />}
-      </Map>
-    </div>
-  )
-}
-
-function PopupInfo({
-  info,
-  setFunc,
-}: {
-  info: PopupInfoType
-  setFunc: React.Dispatch<React.SetStateAction<PopupInfoType | null>>
-}) {
-  const displayParam = [
+  const mapCardDisplayParam = [
     '市外局番',
     '番号領域',
     '都道府県',
@@ -352,28 +278,178 @@ function PopupInfo({
     '一部地域詳細表示',
   ]
   const cityOptions = {
-    areaDisplayFull: displayParam.includes('一部地域詳細表示'),
+    areaDisplayFull: true,
     isQuiz: false,
   }
-  // TODO: MA一意になるようにする
-  const { MAComps } = new MACompListContent().filter(
-    'MA',
-    info.properties['_MA名'],
-  )
+
   return (
-    <Popup
-      longitude={info.longitude}
-      latitude={info.latitude}
-      anchor="bottom"
-      onClose={() => setFunc(null)}
-      closeOnClick={false}
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 420px',
+        width: '100vw',
+        height: '100vh',
+      }}
     >
-      <MAAreaCodeInfoCards
-        MAComps={MAComps}
-        displayParam={displayParam}
-        cityOptions={cityOptions}
-      />
-    </Popup>
+      <div style={{ position: 'relative', minWidth: 0 }}>
+        <div
+          style={{
+            position: 'absolute',
+            zIndex: 1,
+            top: 12,
+            left: 12,
+            padding: '8px 12px',
+            backgroundColor: 'rgba(255,255,255,0.9)',
+            borderRadius: 8,
+            boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+            fontSize: 14,
+          }}
+        >
+          <label style={{ display: 'block', marginBottom: 4 }}>
+            <input
+              type="checkbox"
+              checked={showMA}
+              onChange={(event) => setShowMA(event.target.checked)}
+            />{' '}
+            MA地図
+          </label>
+          <label style={{ display: 'block' }}>
+            <input
+              type="checkbox"
+              checked={showDigits2}
+              onChange={(event) => setShowDigits2(event.target.checked)}
+            />{' '}
+            市外局番2桁地図
+          </label>
+        </div>
+        <Map
+          initialViewState={{
+            longitude: 139.76711,
+            latitude: 35.68074,
+            zoom: 6,
+          }}
+          style={{ position: 'absolute', top: 0, bottom: 0, width: '100%' }}
+          mapStyle={MA_MAP_STYLE}
+          onClick={onClick}
+          onMouseMove={onHover}
+          onMouseLeave={clearHoverState}
+          interactiveLayerIds={interactiveLayerIds}
+        >
+          {maGeoData && (
+            <Source
+              id="ma-source"
+              type="geojson"
+              data={maGeoData}
+              generateId={true}
+            >
+              <Layer
+                {...maFillStyle}
+                layout={{ visibility: showMA ? 'visible' : 'none' }}
+              ></Layer>
+              <Layer
+                {...maBorderStyle}
+                layout={{ visibility: showMA ? 'visible' : 'none' }}
+              ></Layer>
+              <Layer
+                {...maActiveBorderStyle}
+                layout={{ visibility: showMA ? 'visible' : 'none' }}
+              ></Layer>
+              <Layer
+                {...maLabelStyle}
+                layout={{
+                  ...maLabelStyle.layout,
+                  visibility: showMA ? 'visible' : 'none',
+                }}
+              ></Layer>
+            </Source>
+          )}
+          {digits2GeoData && (
+            <Source
+              id="digits2-source"
+              type="geojson"
+              data={digits2GeoData}
+              generateId={true}
+            >
+              <Layer
+                {...digits2BorderStyle}
+                layout={{ visibility: showDigits2 ? 'visible' : 'none' }}
+              ></Layer>
+              <Layer
+                {...digits2LabelStyle}
+                layout={{
+                  ...digits2LabelStyle.layout,
+                  visibility: showDigits2 ? 'visible' : 'none',
+                }}
+              ></Layer>
+            </Source>
+          )}
+        </Map>
+      </div>
+      <div
+        style={{
+          borderLeft: '1px solid #d1d5db',
+          background: '#f9fafb',
+          padding: 12,
+          overflowY: 'auto',
+        }}
+      >
+        <h2 style={{ margin: '4px 0 12px', fontSize: 18 }}>アクティブなMA</h2>
+        {activeMAs.length === 0 && (
+          <p style={{ margin: 0, color: '#4b5563' }}>
+            地図上のMAをクリックすると、ここに情報を表示します。
+          </p>
+        )}
+        {activeMAs.map((activeMA) => {
+          const { MAComps } = new MACompListContent().filter(
+            'MA',
+            activeMA.properties['_MA名'],
+          )
+          return (
+            <div
+              key={activeMA.featureId}
+              style={{
+                marginBottom: 12,
+                padding: 10,
+                border: '1px solid #e5e7eb',
+                borderRadius: 8,
+                backgroundColor: '#ffffff',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: 8,
+                }}
+              >
+                <strong>{activeMA.properties['_MA名']}</strong>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!mapRef.current) return
+                    mapRef.current.setFeatureState(
+                      { source: 'ma-source', id: activeMA.featureId },
+                      { active: false },
+                    )
+                    setActiveMAs((prev) =>
+                      prev.filter((ma) => ma.featureId !== activeMA.featureId),
+                    )
+                  }}
+                >
+                  ×
+                </button>
+              </div>
+              <MAAreaCodeInfoCards
+                MAComps={MAComps}
+                displayParam={mapCardDisplayParam}
+                cityOptions={cityOptions}
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
   )
 }
 

--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -209,9 +209,9 @@ function App() {
     type: 'line',
     filter: ['boolean', ['feature-state', 'active'], false],
     paint: {
-      'line-color': '#ef4444',
-      'line-width': ['interpolate', ['linear'], ['zoom'], 4, 1.4, 8, 3],
-      'line-opacity': 0.95,
+      'line-color': '#dc2626',
+      'line-width': ['interpolate', ['linear'], ['zoom'], 4, 2.4, 8, 4.5],
+      'line-opacity': 1,
     },
   }
 
@@ -351,10 +351,6 @@ function App() {
                 layout={{ visibility: showMA ? 'visible' : 'none' }}
               ></Layer>
               <Layer
-                {...maActiveBorderStyle}
-                layout={{ visibility: showMA ? 'visible' : 'none' }}
-              ></Layer>
-              <Layer
                 {...maLabelStyle}
                 layout={{
                   ...maLabelStyle.layout,
@@ -382,6 +378,13 @@ function App() {
                 }}
               ></Layer>
             </Source>
+          )}
+
+          {maGeoData && (
+            <Layer
+              {...maActiveBorderStyle}
+              layout={{ visibility: showMA ? 'visible' : 'none' }}
+            ></Layer>
           )}
         </Map>
       </div>

--- a/src/areacode/features/map/mapStyles.ts
+++ b/src/areacode/features/map/mapStyles.ts
@@ -1,0 +1,105 @@
+import type {
+  FillLayerSpecification,
+  LineLayerSpecification,
+  SymbolLayerSpecification,
+} from 'maplibre-gl'
+
+export const MA_MAP_STYLE =
+  'https://tile.openstreetmap.jp/styles/osm-bright-ja/style.json'
+
+export const maFillStyle: FillLayerSpecification = {
+  source: 'ma-source',
+  id: 'ma-fills',
+  type: 'fill',
+  paint: {
+    'fill-color': ['get', 'fillColor'],
+    'fill-outline-color': ['get', 'fillColor'],
+    'fill-opacity': [
+      'case',
+      ['boolean', ['feature-state', 'hover'], false],
+      0.55,
+      0.85,
+    ],
+  },
+}
+
+export const maBorderStyle: LineLayerSpecification = {
+  source: 'ma-source',
+  id: 'ma-borders',
+  type: 'line',
+  paint: {
+    'line-color': '#1a1a1a',
+    'line-width': ['interpolate', ['linear'], ['zoom'], 4, 0.4, 8, 1.2],
+    'line-opacity': 0.7,
+  },
+}
+
+export const activeMAFillStyle: FillLayerSpecification = {
+  source: 'active-ma-source',
+  id: 'active-ma-fills',
+  type: 'fill',
+  paint: {
+    'fill-color': '#ef4444',
+    'fill-opacity': 0.18,
+  },
+}
+
+export const activeMABorderStyle: LineLayerSpecification = {
+  source: 'active-ma-source',
+  id: 'active-ma-borders',
+  type: 'line',
+  paint: {
+    'line-color': '#dc2626',
+    'line-width': ['interpolate', ['linear'], ['zoom'], 4, 2.8, 8, 5.2],
+    'line-opacity': 1,
+  },
+}
+
+export const maLabelStyle: SymbolLayerSpecification = {
+  source: 'ma-source',
+  id: 'ma-labels',
+  type: 'symbol',
+  layout: {
+    'text-field': ['coalesce', ['get', '_MA名']],
+    'text-size': ['interpolate', ['linear'], ['zoom'], 5, 8, 8, 11],
+    'text-font': ['Roboto', 'Noto Sans JP', 'sans-serif'],
+    'text-allow-overlap': false,
+    'text-ignore-placement': false,
+  },
+  paint: {
+    'text-color': '#111827',
+    'text-halo-color': '#ffffff',
+    'text-halo-width': 1.1,
+    'text-halo-blur': 0.2,
+  },
+}
+
+export const digits2BorderStyle: LineLayerSpecification = {
+  source: 'digits2-source',
+  id: 'digits2-borders',
+  type: 'line',
+  paint: {
+    'line-color': '#374151',
+    'line-width': ['interpolate', ['linear'], ['zoom'], 4, 0.6, 8, 2.0],
+    'line-opacity': 0.85,
+  },
+}
+
+export const digits2LabelStyle: SymbolLayerSpecification = {
+  source: 'digits2-source',
+  id: 'digits2-labels',
+  type: 'symbol',
+  layout: {
+    'text-field': ['coalesce', ['get', '市外局番2桁']],
+    'text-size': ['interpolate', ['linear'], ['zoom'], 5, 20, 8, 30],
+    'text-font': ['Roboto', 'sans-serif'],
+    'text-allow-overlap': false,
+    'text-ignore-placement': false,
+  },
+  paint: {
+    'text-color': '#111827',
+    'text-halo-color': '#ffffff',
+    'text-halo-width': 1.3,
+    'text-halo-blur': 0.2,
+  },
+}

--- a/src/areacode/features/map/types.ts
+++ b/src/areacode/features/map/types.ts
@@ -1,0 +1,17 @@
+import type { Feature, FeatureCollection, Geometry } from 'geojson'
+
+export type HoverState = {
+  sourceId: 'ma-source' | 'digits2-source'
+  featureId: string | number
+}
+
+export type ActiveMAInfo = {
+  featureId: string | number
+  properties: Record<string, string>
+  feature: Feature<Geometry>
+}
+
+export const EMPTY_FEATURE_COLLECTION: FeatureCollection<Geometry> = {
+  type: 'FeatureCollection',
+  features: [],
+}


### PR DESCRIPTION
### Motivation
- 地図上でMAをクリックした際に単一のポップアップではなく、複数のMAをアクティブにできるUIにして一覧で扱えるようにするため、選択情報を右側に常時表示するUIへ変更しました。

### Description
- `src/areacode/features/map/index.tsx` を変更し、地図ポップアップ表示を廃止して右サイドパネルで詳細を表示するレイアウトに切り替えました。
- クリックでMAをトグルする `activeMAs` 状態（`ActiveMAInfo`）を追加し、`map.setFeatureState(..., { active: true/false })` を使って地図上で状態管理するようにしました。
- `feature-state.active` に基づく視覚強調を追加し、塗りの不透明度を上げる処理と `ma-active-borders` レイヤーで赤色の境界ハイライトを実装しました。
- 右サイドパネルは `grid` レイアウトで地図と並列表示し、各アクティブMAは `MAAreaCodeInfoCards` コンポーネントでカード表示し個別の解除ボタンを付与しました。

### Testing
- `npx prettier --write src/areacode/features/map/index.tsx` を実行してフォーマットを適用済み（成功）。
- `npm run build` を実行してプロダクションビルドを生成できることを確認（ビルド成功、他ファイル由来の ESLint warning が出ています）。
- ビルド成果物を `python -m http.server` で配信してから Playwright スクリプトで `http://127.0.0.1:4173/areacode/map` を開き、地図上をクリックして複数MAが右サイドに蓄積される挙動を自動操作・スクリーンショットで確認（成功）。
- `npm start` による開発サーバー起動はこの環境で `react-refresh/runtime.js` に起因するモジュール解決エラーにより失敗しました（環境依存の問題）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eefb91bac832980b333eb2ad8ebc6)