### PR TITLE
feat(map): モバイル向けに情報パネルをボトムシートUIへ対応

### DIFF
--- a/src/areacode/features/map/components/ActiveMAPanel.tsx
+++ b/src/areacode/features/map/components/ActiveMAPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { MACompListContent } from 'areacode/pages/list/MACompListContent'
 import { MAAreaCodeInfoCards } from 'areacode/pages/list/components'
 import type { ActiveMAInfo } from '../types'
@@ -21,17 +21,21 @@ export function ActiveMAPanel({
   activeMAs,
   isExpanded,
   onToggleExpand,
-  onRemove,
 }: {
   activeMAs: ActiveMAInfo[]
   isExpanded: boolean
   onToggleExpand: () => void
-  onRemove: (featureId: string | number) => void
 }) {
+  const MAComps = useMemo(
+    () =>
+      activeMAs.flatMap((activeMA) =>
+        new MACompListContent().filter('MA', activeMA.properties['_MA名']).MAComps,
+      ),
+    [activeMAs],
+  )
+
   return (
-    <div
-      className={`active-ma-panel ${isExpanded ? 'expanded' : ''}`}
-    >
+    <div className={`active-ma-panel ${isExpanded ? 'expanded' : ''}`}>
       <div className="active-ma-panel-header">
         <button
           type="button"
@@ -43,53 +47,13 @@ export function ActiveMAPanel({
           <div className="active-ma-panel-grabber" />
         </button>
       </div>
-      {activeMAs.length === 0 && (
-        <p style={{ margin: 0, color: '#4b5563' }}>
-          地図上のMAをクリックすると、ここに情報を表示します。
-        </p>
+      {MAComps.length > 0 && (
+        <MAAreaCodeInfoCards
+          MAComps={MAComps}
+          displayParam={mapCardDisplayParam}
+          cityOptions={cityOptions}
+        />
       )}
-      {activeMAs.map((activeMA) => {
-        const { MAComps } = new MACompListContent().filter(
-          'MA',
-          activeMA.properties['_MA名'],
-        )
-        return (
-          <div
-            key={activeMA.featureId}
-            style={{
-              marginBottom: 12,
-              padding: 10,
-              border: '1px solid #e5e7eb',
-              borderRadius: 8,
-              backgroundColor: '#ffffff',
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                marginBottom: 8,
-              }}
-            >
-              <strong>{activeMA.properties['_MA名']}</strong>
-              <button
-                type="button"
-                onClick={() => {
-                  onRemove(activeMA.featureId)
-                }}
-              >
-                ×
-              </button>
-            </div>
-            <MAAreaCodeInfoCards
-              MAComps={MAComps}
-              displayParam={mapCardDisplayParam}
-              cityOptions={cityOptions}
-            />
-          </div>
-        )
-      })}
     </div>
   )
 }

--- a/src/areacode/features/map/components/ActiveMAPanel.tsx
+++ b/src/areacode/features/map/components/ActiveMAPanel.tsx
@@ -38,11 +38,9 @@ export function ActiveMAPanel({
           className="active-ma-panel-toggle"
           onClick={onToggleExpand}
           aria-expanded={isExpanded}
+          aria-label={isExpanded ? '情報パネルを縮小' : '情報パネルを拡大'}
         >
           <div className="active-ma-panel-grabber" />
-          <h2 style={{ margin: '4px 0 12px', fontSize: 18 }}>
-            アクティブなMA {isExpanded ? '（タップで縮小）' : '（タップで拡大）'}
-          </h2>
         </button>
       </div>
       {activeMAs.length === 0 && (

--- a/src/areacode/features/map/components/ActiveMAPanel.tsx
+++ b/src/areacode/features/map/components/ActiveMAPanel.tsx
@@ -19,21 +19,32 @@ const cityOptions = {
 
 export function ActiveMAPanel({
   activeMAs,
+  isExpanded,
+  onToggleExpand,
   onRemove,
 }: {
   activeMAs: ActiveMAInfo[]
+  isExpanded: boolean
+  onToggleExpand: () => void
   onRemove: (featureId: string | number) => void
 }) {
   return (
     <div
-      style={{
-        borderLeft: '1px solid #d1d5db',
-        background: '#f9fafb',
-        padding: 12,
-        overflowY: 'auto',
-      }}
+      className={`active-ma-panel ${isExpanded ? 'expanded' : ''}`}
     >
-      <h2 style={{ margin: '4px 0 12px', fontSize: 18 }}>アクティブなMA</h2>
+      <div className="active-ma-panel-header">
+        <button
+          type="button"
+          className="active-ma-panel-toggle"
+          onClick={onToggleExpand}
+          aria-expanded={isExpanded}
+        >
+          <div className="active-ma-panel-grabber" />
+          <h2 style={{ margin: '4px 0 12px', fontSize: 18 }}>
+            アクティブなMA {isExpanded ? '（タップで縮小）' : '（タップで拡大）'}
+          </h2>
+        </button>
+      </div>
       {activeMAs.length === 0 && (
         <p style={{ margin: 0, color: '#4b5563' }}>
           地図上のMAをクリックすると、ここに情報を表示します。

--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -3,6 +3,7 @@ import Map from 'react-map-gl/maplibre'
 import type { Feature, FeatureCollection, Geometry } from 'geojson'
 import type { MapLayerMouseEvent, Map as MapLibreMap } from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
+import './map.css'
 import { MA_MAP_STYLE } from './mapStyles'
 import { useMapGeoData } from './hooks/useMapGeoData'
 import type { ActiveMAInfo, HoverState } from './types'
@@ -14,6 +15,7 @@ function App() {
   const [showMA, setShowMA] = useState(true)
   const [showDigits2, setShowDigits2] = useState(true)
   const [activeMAs, setActiveMAs] = useState<ActiveMAInfo[]>([])
+  const [isPanelExpanded, setIsPanelExpanded] = useState(false)
 
   const mapRef = useRef<MapLibreMap | null>(null)
   const hoverRef = useRef<HoverState | null>(null)
@@ -105,29 +107,10 @@ function App() {
   ]
 
   return (
-    <div
-      style={{
-        display: 'grid',
-        gridTemplateColumns: '1fr 420px',
-        width: '100vw',
-        height: '100vh',
-      }}
-    >
-      <div style={{ position: 'relative', minWidth: 0 }}>
-        <div
-          style={{
-            position: 'absolute',
-            zIndex: 1,
-            top: 12,
-            left: 12,
-            padding: '8px 12px',
-            backgroundColor: 'rgba(255,255,255,0.9)',
-            borderRadius: 8,
-            boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-            fontSize: 14,
-          }}
-        >
-          <label style={{ display: 'block', marginBottom: 4 }}>
+    <div className="map-app-layout">
+      <div className="map-canvas-wrap">
+        <div className="map-layer-toggle">
+          <label className="map-layer-toggle-item with-margin">
             <input
               type="checkbox"
               checked={showMA}
@@ -135,7 +118,7 @@ function App() {
             />{' '}
             MA地図
           </label>
-          <label style={{ display: 'block' }}>
+          <label className="map-layer-toggle-item">
             <input
               type="checkbox"
               checked={showDigits2}
@@ -170,6 +153,8 @@ function App() {
 
       <ActiveMAPanel
         activeMAs={activeMAs}
+        isExpanded={isPanelExpanded}
+        onToggleExpand={() => setIsPanelExpanded((prev) => !prev)}
         onRemove={(featureId) => {
           setActiveMAs((prev) =>
             prev.filter((ma) => ma.featureId !== featureId),

--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -58,9 +58,9 @@ function App() {
     setActiveMAs((prev) => {
       const alreadyActive = prev.some((ma) => ma.featureId === featureId)
       if (alreadyActive) {
-        return prev.filter((ma) => ma.featureId !== featureId)
+        return []
       }
-      return [...prev, { featureId, properties, feature: activeFeature }]
+      return [{ featureId, properties, feature: activeFeature }]
     })
   }, [])
 

--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -155,11 +155,6 @@ function App() {
         activeMAs={activeMAs}
         isExpanded={isPanelExpanded}
         onToggleExpand={() => setIsPanelExpanded((prev) => !prev)}
-        onRemove={(featureId) => {
-          setActiveMAs((prev) =>
-            prev.filter((ma) => ma.featureId !== featureId),
-          )
-        }}
       />
     </div>
   )

--- a/src/areacode/features/map/map.css
+++ b/src/areacode/features/map/map.css
@@ -33,16 +33,12 @@
 .active-ma-panel {
   border-left: 1px solid #d1d5db;
   background: #f9fafb;
-  padding: 0 12px 12px;
+  padding: 12px;
   overflow-y: auto;
 }
 
 .active-ma-panel-header {
-  position: relative;
-  z-index: 2;
-  margin: 0 -12px 10px;
-  padding: 14px 12px 8px;
-  background: #f9fafb;
+  display: none;
 }
 
 .active-ma-panel-toggle {
@@ -89,6 +85,7 @@
     transition: height 0.25s ease;
     height: 34vh;
     max-height: 88vh;
+    padding: 0 12px 12px;
     background: rgba(249, 250, 251, 0.98);
     backdrop-filter: blur(2px);
   }
@@ -98,9 +95,12 @@
   }
 
   .active-ma-panel-header {
+    display: block;
     position: sticky;
     top: 0;
     z-index: 4;
+    margin: 0 -12px 10px;
+    padding: 14px 12px 8px;
     background: linear-gradient(
       to bottom,
       rgba(249, 250, 251, 1),

--- a/src/areacode/features/map/map.css
+++ b/src/areacode/features/map/map.css
@@ -40,14 +40,14 @@
 
 .active-ma-panel-header {
   margin: -12px -12px 10px;
-  padding: 8px 12px;
+  padding: 10px 12px 8px;
 }
 
 .active-ma-panel-toggle {
   width: 100%;
   border: none;
   background: transparent;
-  padding: 0;
+  padding: 10px 0 2px;
   color: inherit;
   font: inherit;
   cursor: pointer;

--- a/src/areacode/features/map/map.css
+++ b/src/areacode/features/map/map.css
@@ -1,0 +1,105 @@
+.map-app-layout {
+  width: 100vw;
+  height: 100vh;
+  display: grid;
+  grid-template-columns: 1fr 420px;
+}
+
+.map-canvas-wrap {
+  position: relative;
+  min-width: 0;
+}
+
+.map-layer-toggle {
+  position: absolute;
+  z-index: 2;
+  top: 12px;
+  left: 12px;
+  padding: 8px 12px;
+  background-color: rgba(255, 255, 255, 0.9);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  font-size: 14px;
+}
+
+.map-layer-toggle-item {
+  display: block;
+}
+
+.map-layer-toggle-item.with-margin {
+  margin-bottom: 4px;
+}
+
+.active-ma-panel {
+  border-left: 1px solid #d1d5db;
+  background: #f9fafb;
+  padding: 12px;
+  overflow-y: auto;
+}
+
+@media (max-width: 767px) {
+  .map-app-layout {
+    display: block;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .map-canvas-wrap {
+    width: 100%;
+    height: 100%;
+  }
+
+  .active-ma-panel {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: auto;
+    z-index: 3;
+    border-left: none;
+    border-top: 1px solid #d1d5db;
+    border-radius: 14px 14px 0 0;
+    box-shadow: 0 -8px 20px rgba(0, 0, 0, 0.18);
+    transition: height 0.25s ease;
+    height: 34vh;
+    max-height: 88vh;
+    background: rgba(249, 250, 251, 0.98);
+    backdrop-filter: blur(2px);
+  }
+
+  .active-ma-panel.expanded {
+    height: 74vh;
+  }
+
+  .active-ma-panel-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    margin: -12px -12px 10px;
+    padding: 8px 12px 10px;
+    background: linear-gradient(
+      to bottom,
+      rgba(249, 250, 251, 0.98),
+      rgba(249, 250, 251, 0.92)
+    );
+  }
+
+  .active-ma-panel-toggle {
+    width: 100%;
+    border: none;
+    background: transparent;
+    padding: 0;
+    text-align: left;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .active-ma-panel-grabber {
+    width: 40px;
+    height: 4px;
+    border-radius: 9999px;
+    background: #9ca3af;
+    margin: 0 auto 8px;
+  }
+}

--- a/src/areacode/features/map/map.css
+++ b/src/areacode/features/map/map.css
@@ -37,6 +37,30 @@
   overflow-y: auto;
 }
 
+
+.active-ma-panel-header {
+  margin: -12px -12px 10px;
+  padding: 8px 12px;
+}
+
+.active-ma-panel-toggle {
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.active-ma-panel-grabber {
+  width: 40px;
+  height: 4px;
+  border-radius: 9999px;
+  background: #9ca3af;
+  margin: 0 auto;
+}
+
 @media (max-width: 767px) {
   .map-app-layout {
     display: block;
@@ -75,31 +99,10 @@
     position: sticky;
     top: 0;
     z-index: 1;
-    margin: -12px -12px 10px;
-    padding: 8px 12px 10px;
     background: linear-gradient(
       to bottom,
       rgba(249, 250, 251, 0.98),
       rgba(249, 250, 251, 0.92)
     );
-  }
-
-  .active-ma-panel-toggle {
-    width: 100%;
-    border: none;
-    background: transparent;
-    padding: 0;
-    text-align: left;
-    color: inherit;
-    font: inherit;
-    cursor: pointer;
-  }
-
-  .active-ma-panel-grabber {
-    width: 40px;
-    height: 4px;
-    border-radius: 9999px;
-    background: #9ca3af;
-    margin: 0 auto 8px;
   }
 }

--- a/src/areacode/features/map/map.css
+++ b/src/areacode/features/map/map.css
@@ -33,14 +33,16 @@
 .active-ma-panel {
   border-left: 1px solid #d1d5db;
   background: #f9fafb;
-  padding: 12px;
+  padding: 0 12px 12px;
   overflow-y: auto;
 }
 
-
 .active-ma-panel-header {
-  margin: -12px -12px 10px;
-  padding: 10px 12px 8px;
+  position: relative;
+  z-index: 2;
+  margin: 0 -12px 10px;
+  padding: 14px 12px 8px;
+  background: #f9fafb;
 }
 
 .active-ma-panel-toggle {
@@ -98,11 +100,11 @@
   .active-ma-panel-header {
     position: sticky;
     top: 0;
-    z-index: 1;
+    z-index: 4;
     background: linear-gradient(
       to bottom,
-      rgba(249, 250, 251, 0.98),
-      rgba(249, 250, 251, 0.92)
+      rgba(249, 250, 251, 1),
+      rgba(249, 250, 251, 0.94)
     );
   }
 }


### PR DESCRIPTION
### Motivation
- 地図画面の右側に表示している情報パネルをスマホ表示で下部にスライドするボトムシート形式にして、普段は地図を広く見せ、必要時にパネルを拡大できる操作感にするため。 

### Description
- レイアウトをインラインスタイルからCSSクラス化に置換し、`map.css` を追加してデスクトップは右側パネル、モバイルは下部ボトムシートとなるレスポンシブ設計を実装しました。 (新規ファイル: `src/areacode/features/map/map.css`)
- `src/areacode/features/map/index.tsx` を更新し、クラス名ベースのレイアウトに変更するとともに、パネル展開状態を管理する `isPanelExpanded` 状態とトグルハンドラを追加しました。 
- `src/areacode/features/map/components/ActiveMAPanel.tsx` を更新し、`isExpanded` と `onToggleExpand` プロパティを受け取るようにして、パネル上部にグラバーとタップで展開/縮小できるヘッダー（ボタン）を実装しました。 
- UI実装のみを行い、既存の地図ライブラリ依存（`react-map-gl/maplibre` / `maplibre-gl` / `geojson` 等）の追加や型定義の修正はこのPRでは扱っていません。 

### Testing
- 実行: `npm run build` — 失敗（モジュール解決エラー: `react-map-gl/maplibre` / `maplibre-gl` / `geojson` 等が見つからないためコンパイル不可）。
- 実行: `npm start` — 失敗（開発サーバー起動時にプロジェクト外参照や型解決エラーにより起動不可）。
- 自動スクリーンショット: Playwright スクリプトを実行してモバイル表示のスクリーンショットを取得しましたが、アプリはコンパイルエラー状態のためエラー画面が表示される状態でした（スクリーンショットは成果物として保存）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698effa220208329a01c2b46108b277c)