### PR TITLE
fix(map): use source geometry for active MA highlight

### DIFF
--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -47,12 +47,22 @@ function App() {
     }
 
     const featureId = feature.id
-    const properties = feature.properties as Record<string, string>
+    const sourceFeature =
+      typeof featureId === 'number' ? maGeoData.features[featureId] : undefined
+
+    const properties =
+      (sourceFeature?.properties as Record<string, string> | undefined) ??
+      (feature.properties as Record<string, string>)
+
+    const geometry =
+      (sourceFeature?.geometry as Geometry | undefined) ??
+      (feature.geometry as Geometry)
+
     const activeFeature: Feature<Geometry> = {
       type: 'Feature',
       id: featureId,
       properties,
-      geometry: feature.geometry as Geometry,
+      geometry,
     }
 
     setActiveMAs((prev) => {
@@ -62,7 +72,7 @@ function App() {
       }
       return [{ featureId, properties, feature: activeFeature }]
     })
-  }, [])
+  }, [maGeoData.features])
 
   const onHover = useCallback(
     (event: MapLayerMouseEvent) => {


### PR DESCRIPTION
### Motivation
- Clicking an MA used the rendered (possibly clipped) feature geometry, which produced straight/trimmed highlight shapes when the region extended outside the viewport; the intent is to use the original source geometry so highlights match the true MA outline.

### Description
- Updated `src/areacode/features/map/index.tsx` so `onClick` looks up the full feature from `maGeoData.features` by `feature.id` and uses its `geometry`/`properties` with a fallback to the clicked feature, and added `maGeoData.features` to the `onClick` dependency array.

### Testing
- Ran unit tests with `npm test -- --watchAll=false --runInBand src/areacode/components/color.test.tsx`, which passed; `npm run build` failed due to unrelated environment/module resolution issues (`react-map-gl/maplibre` and type/module resolution), and starting the dev server (`npm start`) failed for the same environment-related reasons.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f0a8ec9dc8329a156dd81302fe335)