### PR TITLE
地図ページに検索パネルとMAフォーカス表示（fitBounds）を追加

### DIFF
--- a/src/areacode/features/map/components/ActiveMAPanel.tsx
+++ b/src/areacode/features/map/components/ActiveMAPanel.tsx
@@ -54,7 +54,7 @@ export function ActiveMAPanel({
       ...new Set(
         activeMAs.map(
           (activeMA) =>
-            `${activeMA.properties['_都道府県名']}|${activeMA.properties['_MA名']}`,
+            `${activeMA.properties['_市外局番']}|${activeMA.properties['_MA名']}`,
         ),
       ),
     ],
@@ -64,9 +64,9 @@ export function ActiveMAPanel({
   const MAComps = useMemo(
     () =>
       uniqueMAKeys.flatMap((key) => {
-        const [pref, maName] = key.split('|')
+        const [areaCode, maName] = key.split('|')
         return new MACompListContent()
-          .filter('pref', pref)
+          .filter('code', `0${areaCode}`)
           .MAComps.filter((maComp) => maComp.MAName === maName)
       }),
     [uniqueMAKeys],

--- a/src/areacode/features/map/components/ActiveMAPanel.tsx
+++ b/src/areacode/features/map/components/ActiveMAPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { MACompListContent } from 'areacode/pages/list/MACompListContent'
 import { MAAreaCodeInfoCards } from 'areacode/pages/list/components'
+import type { CityInfo } from 'areacode/data/cityList'
 import type { ActiveMAInfo } from '../types'
 
 const mapCardDisplayParam = [
@@ -12,26 +13,76 @@ const mapCardDisplayParam = [
   '一部地域詳細表示',
 ]
 
-const cityOptions = {
+const mapCardCityOptions = {
   areaDisplayFull: true,
   isQuiz: false,
+}
+
+function toPrefCountyCityName(city: CityInfo): string {
+  return `${city.pref}${city.county.name}${city.county.type}${city.name}${city.type}`
 }
 
 export function ActiveMAPanel({
   activeMAs,
   isExpanded,
   onToggleExpand,
+  prefOptions,
+  cityOptions,
+  digits3Options,
+  selectedPref,
+  selectedCity,
+  selectedDigits3,
+  onPrefSelect,
+  onCitySelect,
+  onDigits3Select,
 }: {
   activeMAs: ActiveMAInfo[]
   isExpanded: boolean
   onToggleExpand: () => void
+  prefOptions: string[]
+  cityOptions: CityInfo[]
+  digits3Options: string[]
+  selectedPref: string
+  selectedCity: string
+  selectedDigits3: string
+  onPrefSelect: (pref: string) => void
+  onCitySelect: (city: string) => void
+  onDigits3Select: (digits3: string) => void
 }) {
+  const uniqueMAKeys = useMemo(
+    () => [
+      ...new Set(
+        activeMAs.map(
+          (activeMA) =>
+            `${activeMA.properties['_都道府県名']}|${activeMA.properties['_MA名']}`,
+        ),
+      ),
+    ],
+    [activeMAs],
+  )
+
   const MAComps = useMemo(
     () =>
-      activeMAs.flatMap((activeMA) =>
-        new MACompListContent().filter('MA', activeMA.properties['_MA名']).MAComps,
+      uniqueMAKeys.flatMap((key) => {
+        const [pref, maName] = key.split('|')
+        return new MACompListContent()
+          .filter('pref', pref)
+          .MAComps.filter((maComp) => maComp.MAName === maName)
+      }),
+    [uniqueMAKeys],
+  )
+
+  const uniqueMAComps = useMemo(
+    () =>
+      MAComps.filter(
+        (maComp, index, self) =>
+          self.findIndex(
+            (item) =>
+              `${item.pref}|${item.MAName}|${item.areaCode}` ===
+              `${maComp.pref}|${maComp.MAName}|${maComp.areaCode}`,
+          ) === index,
       ),
-    [activeMAs],
+    [MAComps],
   )
 
   return (
@@ -47,11 +98,63 @@ export function ActiveMAPanel({
           <div className="active-ma-panel-grabber" />
         </button>
       </div>
-      {MAComps.length > 0 && (
+
+      <div className="map-search-panel">
+        <h3 className="map-search-panel-title">検索</h3>
+        <label className="map-search-panel-label">
+          都道府県
+          <select
+            value={selectedPref}
+            onChange={(event) => onPrefSelect(event.target.value)}
+          >
+            <option value="">選択してください</option>
+            {prefOptions.map((pref) => (
+              <option key={pref} value={pref}>
+                {pref}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="map-search-panel-label">
+          市町村
+          <select
+            value={selectedCity}
+            onChange={(event) => onCitySelect(event.target.value)}
+          >
+            <option value="">選択してください</option>
+            {cityOptions.map((city) => {
+              const value = toPrefCountyCityName(city)
+              return (
+                <option key={`${city.pref}-${city.code}`} value={value}>
+                  {value}
+                </option>
+              )
+            })}
+          </select>
+        </label>
+
+        <label className="map-search-panel-label">
+          3桁番号
+          <select
+            value={selectedDigits3}
+            onChange={(event) => onDigits3Select(event.target.value)}
+          >
+            <option value="">選択してください</option>
+            {digits3Options.map((digits3) => (
+              <option key={digits3} value={digits3}>
+                {digits3}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {uniqueMAComps.length > 0 && (
         <MAAreaCodeInfoCards
-          MAComps={MAComps}
+          MAComps={uniqueMAComps}
           displayParam={mapCardDisplayParam}
-          cityOptions={cityOptions}
+          cityOptions={mapCardCityOptions}
         />
       )}
     </div>

--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -92,8 +92,8 @@ function App() {
 
   const activateFeatures = useCallback(
     (predicate: (properties: Record<string, string>) => boolean) => {
-      const nextActiveMAs: ActiveMAInfo[] = maGeoData.features
-        .map((feature, index) => {
+      const matchedActiveMAs: Array<ActiveMAInfo | null> =
+        maGeoData.features.map((feature, index) => {
           const properties = (feature.properties ?? {}) as Record<
             string,
             string
@@ -102,20 +102,23 @@ function App() {
             return null
           }
 
+          const featureId: ActiveMAInfo['featureId'] = index
           const activeFeature: Feature<Geometry> = {
             type: 'Feature',
-            id: index,
+            id: featureId,
             properties,
             geometry: feature.geometry,
           }
 
           return {
-            featureId: index,
+            featureId,
             properties,
             feature: activeFeature,
           }
         })
-        .filter((item): item is ActiveMAInfo => item !== null)
+      const nextActiveMAs = matchedActiveMAs.filter(
+        (item): item is ActiveMAInfo => item !== null,
+      )
 
       setActiveMAs(nextActiveMAs)
 

--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -293,7 +293,7 @@ function App() {
         return
       }
 
-      activateByMAKeySet(getMAKeySetFromFilter('code_prefix', `0${digits3}`))
+      activateByMAKeySet(getMAKeySetFromFilter('code_prefix', `${digits3}`))
     },
     [activateByMAKeySet],
   )

--- a/src/areacode/features/map/map.css
+++ b/src/areacode/features/map/map.css
@@ -61,6 +61,40 @@
   margin: 0 auto;
 }
 
+.map-search-panel {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 12px;
+}
+
+.map-search-panel-title {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.map-search-panel-label {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 13px;
+  color: #374151;
+}
+
+.map-search-panel-label:last-child {
+  margin-bottom: 0;
+}
+
+.map-search-panel-label select {
+  margin-top: 4px;
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  padding: 6px 8px;
+  font-size: 14px;
+}
+
 @media (max-width: 767px) {
   .map-app-layout {
     display: block;
@@ -110,8 +144,6 @@
     );
   }
 }
-
-
 
 .digits2-map-label-marker {
   font-family: 'Roboto', sans-serif;


### PR DESCRIPTION
### Motivation
- 右側パネルにトップページ相当の検索UI（都道府県・市町村・3桁番号）を置き、地図操作と連携して関連するMAをすばやく確認できるようにするための変更です。 
- 検索で選択した項目に関連するMAをアクティブ化し、カード表示・ハイライト・地図の自動移動・拡大（描画エリアに収まるように）を実現します。

### Description
- 追加・更新した主なファイルは `src/areacode/features/map/index.tsx`, `src/areacode/features/map/components/ActiveMAPanel.tsx`, `src/areacode/features/map/map.css` です。 
- `index.tsx` に検索状態（`selectedPref`, `selectedCity`, `selectedDigits3`）と共通ロジック `activateFeatures` を追加し、`maGeoData.features` から条件に合う feature を抽出して `setActiveMAs` する機能を実装しました。 
- アクティブ化時に対象 feature 群の bbox を算出する `getFeaturesBounds` を追加し、`mapRef.current.fitBounds(...)` で地図を移動・ズームして描画エリアに収めるようにしました。 
- `ActiveMAPanel.tsx` に検索用のセレクトUI（都道府県／市町村／3桁番号）を追加し、選択イベントを親コンポーネントへ通知する props を受け取りカード表示用の MA データを重複除去して渡すようにしました。 
- `map.css` に検索パネル用のスタイルを追加しました（見た目・ラベル・select）。

### Testing
- フォーマット: `npx prettier --write src/areacode/features/map/index.tsx src/areacode/features/map/components/ActiveMAPanel.tsx src/areacode/features/map/map.css` を実行して整形は成功しました。 
- ビルド: `npm run build` を実行したところ、環境の依存関係（`react-map-gl/maplibre` の解決）に起因するエラーでビルドは失敗しました（依存の解決が必要）。 
- 開発サーバー: `npm start` で開発サーバーは起動し、アプリにアクセスできることを確認しました。 
- E2E スナップショット: Playwright スクリプトで `http://127.0.0.1:3000/areacode/map` にアクセスしてスクリーンショットを取得できました（視覚確認用のキャプチャ取得成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f241c71648329870eb5b3fc641e7f)