### PR TITLE
市外局番地図 — 詳細表示順をフィルタ定義の順に固定

### DIFF
--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -131,7 +131,9 @@ function App() {
       )
 
       if (orderedMAKeys.length > 0) {
-        const keyOrder = new Map(orderedMAKeys.map((key, index) => [key, index]))
+        const keyOrder = new globalThis.Map<string, number>(
+          orderedMAKeys.map((key, index) => [key, index]),
+        )
         nextActiveMAs.sort((a, b) => {
           const aIndex =
             keyOrder.get(toMAKey(a.properties['_市外局番'], a.properties['_MA名'])) ??
@@ -140,7 +142,15 @@ function App() {
             keyOrder.get(toMAKey(b.properties['_市外局番'], b.properties['_MA名'])) ??
             Number.MAX_SAFE_INTEGER
 
-          return aIndex - bIndex || a.featureId - b.featureId
+          if (aIndex !== bIndex) {
+            return aIndex - bIndex
+          }
+
+          if (typeof a.featureId === 'number' && typeof b.featureId === 'number') {
+            return a.featureId - b.featureId
+          }
+
+          return String(a.featureId).localeCompare(String(b.featureId))
         })
       }
 

--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
-import Map from 'react-map-gl/maplibre'
+import MapView from 'react-map-gl/maplibre'
 import type {
   Feature,
   FeatureCollection,
@@ -131,15 +131,19 @@ function App() {
       )
 
       if (orderedMAKeys.length > 0) {
-        const keyOrder = new globalThis.Map<string, number>(
-          orderedMAKeys.map((key, index) => [key, index]),
+        const keyOrder = orderedMAKeys.reduce<Record<string, number>>(
+          (order, key, index) => {
+            order[key] = index
+            return order
+          },
+          {},
         )
         nextActiveMAs.sort((a, b) => {
           const aIndex =
-            keyOrder.get(toMAKey(a.properties['_市外局番'], a.properties['_MA名'])) ??
+            keyOrder[toMAKey(a.properties['_市外局番'], a.properties['_MA名'])] ??
             Number.MAX_SAFE_INTEGER
           const bIndex =
-            keyOrder.get(toMAKey(b.properties['_市外局番'], b.properties['_MA名'])) ??
+            keyOrder[toMAKey(b.properties['_市外局番'], b.properties['_MA名'])] ??
             Number.MAX_SAFE_INTEGER
 
           if (aIndex !== bIndex) {
@@ -365,7 +369,7 @@ function App() {
           </label>
         </div>
 
-        <Map
+        <MapView
           initialViewState={{
             longitude: 139.76711,
             latitude: 35.68074,
@@ -390,7 +394,7 @@ function App() {
             showDigits2={showDigits2}
             zoom={mapZoom}
           />
-        </Map>
+        </MapView>
       </div>
 
       <ActiveMAPanel


### PR DESCRIPTION
### Motivation
- 自治体や3桁番号選択時に表示される詳細情報の順番が不明確だったため、`MACompListContent.filter(...)` 内で定義された順序をそのまま表示するように整合させる。

### Description
- `src/areacode/features/map/index.tsx` を変更し、フィルタ結果の MA キーを順序付き配列で取得する `getMAKeysFromFilter` を導入した。
- `activateFeatures` にオプション引数 `orderedMAKeys` を追加し、抽出後の `activeMAs` をその順序でソートするロジックを追加した（同順位は `featureId` で安定化）。
- `activateByMAKeys` を導入して、都道府県・市町村・3桁番号のセレクトハンドラが順序付きキーを渡すように変更した。

### Testing
- `npx eslint src/areacode/features/map/index.tsx` を実行して問題ないことを確認（成功）。
- `npm run build` を実行したが、環境の依存関係（`react-map-gl/maplibre` や `maplibre-gl` 等）の不足によりビルドは失敗（この PR の変更以外の環境依存問題）。
- 開発サーバを起動してページにアクセスし、レンダリングのスクリーンショットを自動取得して表示順の変更を手動確認できる状態を作成（スクリーンショット取得は自動化スクリプトで実行）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f366581a8832997ef0d029a2f138f)