### PR TITLE
fix(map): guard fill color generation for missing area code

### DIFF
--- a/src/areacode/features/map/hooks/useMapGeoData.ts
+++ b/src/areacode/features/map/hooks/useMapGeoData.ts
@@ -4,6 +4,17 @@ import type { Feature, FeatureCollection, Geometry } from 'geojson'
 import { getColorStyleByAreaCode } from 'areacode/components'
 import { EMPTY_FEATURE_COLLECTION } from '../types'
 
+const DEFAULT_FILL_COLOR = '#9ca3af'
+
+function getFillColor(properties: Record<string, string>): string {
+  const areaCode = properties['_市外局番'] ?? properties['市外局番2桁']
+  if (!areaCode || !/^\d{1,3}$/.test(areaCode)) {
+    return DEFAULT_FILL_COLOR
+  }
+
+  return getColorStyleByAreaCode(`0${areaCode}`).background.backgroundColor
+}
+
 export function useMapGeoData() {
   const [maGeoData, setMaGeoData] = useState<FeatureCollection<Geometry>>(
     EMPTY_FEATURE_COLLECTION,
@@ -26,8 +37,7 @@ export function useMapGeoData() {
             ...f,
             properties: {
               ...properties,
-              fillColor: getColorStyleByAreaCode(`0${properties['_市外局番']}`)
-                .background.backgroundColor,
+              fillColor: getFillColor(properties),
             },
           }
         })
@@ -49,8 +59,7 @@ export function useMapGeoData() {
             ...f,
             properties: {
               ...properties,
-              fillColor: getColorStyleByAreaCode(`0${properties['_市外局番']}`)
-                .background.backgroundColor,
+              fillColor: getFillColor(properties),
             },
           }
         })


### PR DESCRIPTION
### Motivation
- Map layers were failing inside maplibre workers with errors like `n is not defined`, likely caused by invalid/missing area-code values being passed into color-generation logic. 
- Ensure feature `fillColor` is always a valid CSS color so worker-side rendering and style evaluation do not receive malformed inputs.

### Description
- Added a fallback color constant `DEFAULT_FILL_COLOR = '#9ca3af'` and a helper `getFillColor(properties)` in `src/areacode/features/map/hooks/useMapGeoData.ts` to centralize color selection. 
- `getFillColor` validates `_市外局番` or `市外局番2桁` with a `/^\d{1,3}$/` check and returns the fallback when missing or malformed. 
- Replaced direct calls to `getColorStyleByAreaCode(...)` with `getFillColor(...)` for both MA and 2-digit GeoJSON transforms so every feature gets a safe `fillColor` property.

### Testing
- Ran `npm run build` which exercised the production build pipeline, but the build failed in this environment with an unrelated module resolution error: `Can't resolve 'react-map-gl/maplibre'`, so the project did not fully compile here. 
- The introduced defensive logic is unit-free and limited to `useMapGeoData`, and the change should prevent the invalid-data cases that trigger worker runtime errors in maplibre.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f644fa44c8329b96caffce3cd9d58)