### PR TITLE
Fix MapLibre label expressions that break in deployed environment

### DIFF
--- a/src/areacode/features/map/mapStyles.ts
+++ b/src/areacode/features/map/mapStyles.ts
@@ -63,17 +63,11 @@ export const maLabelStyle: SymbolLayerSpecification = {
   type: 'symbol',
   layout: {
     'text-field': [
-      'format',
-      ['concat', '0', ['coalesce', ['get', '_市外局番'], '']],
-      {
-        'font-scale': 1.2,
-      },
+      'concat',
+      '0',
+      ['coalesce', ['get', '_市外局番'], ''],
       '\n',
-      {},
       ['coalesce', ['get', '_MA名'], ''],
-      {
-        'font-scale': 0.82,
-      },
     ],
     'text-size': ['interpolate', ['linear'], ['zoom'], 5, 11, 8, 14],
     'text-font': [...JAPANESE_LABEL_FONT_STACK],
@@ -107,7 +101,7 @@ export const digits2LabelStyle: SymbolLayerSpecification = {
   id: 'digits2-labels',
   type: 'symbol',
   layout: {
-    'text-field': ['coalesce', ['get', '市外局番2桁']],
+    'text-field': ['coalesce', ['get', '市外局番2桁'], ''],
     'text-size': ['interpolate', ['linear'], ['zoom'], 5, 20, 8, 30],
     'text-font': [...JAPANESE_LABEL_FONT_STACK],
     'text-allow-overlap': false,


### PR DESCRIPTION
### Motivation
- The production map failed to render layers with a runtime MapLibre error (`n is not defined`), so label expressions were hardened to avoid expression constructs that can be unstable across builds and runtimes.

### Description
- Replaced the `maLabelStyle` `text-field` expression from a `format`-based expression to a simpler `concat` expression that uses `['coalesce', ['get', '_市外局番'], '']` and the MA name to avoid risky expression shapes (file `src/areacode/features/map/mapStyles.ts`).
- Removed embedded `format` parts that used per-piece `font-scale` objects to keep the expression plain and portable. 
- Added an explicit fallback (`''`) to the 2-digit label `coalesce` in `digits2LabelStyle` so missing properties do not produce an invalid expression.

### Testing
- Ran `npx eslint src/areacode/features/map/mapStyles.ts` which passed. 
- Attempted `npm run build`, which surfaced an unrelated pre-existing module resolution error (`Can't resolve 'react-map-gl/maplibre'`) and prevented a full production build. 
- Started the dev server with `npm start` and used an automated Playwright script to open `http://127.0.0.1:3000/areacode/map` and capture a screenshot to validate the map renders after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f676a0e008329b288748b9d12dd80)