### PR TITLE
Add fetch diagnostics and PUBLIC_URL-safe map asset loading; simplify MapLibre label expressions

### DIFF
--- a/src/areacode/features/map/mapStyles.ts
+++ b/src/areacode/features/map/mapStyles.ts
@@ -63,17 +63,11 @@ export const maLabelStyle: SymbolLayerSpecification = {
   type: 'symbol',
   layout: {
     'text-field': [
-      'format',
-      ['concat', '0', ['coalesce', ['get', '_市外局番'], '']],
-      {
-        'font-scale': 1.2,
-      },
+      'concat',
+      '0',
+      ['coalesce', ['get', '_市外局番'], ''],
       '\n',
-      {},
       ['coalesce', ['get', '_MA名'], ''],
-      {
-        'font-scale': 0.82,
-      },
     ],
     'text-size': ['interpolate', ['linear'], ['zoom'], 5, 11, 8, 14],
     'text-font': [...JAPANESE_LABEL_FONT_STACK],
@@ -107,7 +101,7 @@ export const digits2LabelStyle: SymbolLayerSpecification = {
   id: 'digits2-labels',
   type: 'symbol',
   layout: {
-    'text-field': ['coalesce', ['get', '市外局番2桁']],
+    'text-field': ['coalesce', ['get', '市外局番2桁'], ''],
     'text-size': ['interpolate', ['linear'], ['zoom'], 5, 20, 8, 30],
     'text-font': [...JAPANESE_LABEL_FONT_STACK],
     'text-allow-overlap': false,


### PR DESCRIPTION
### Motivation
- The earlier label-expression hardening did not resolve the production failure, and fetch/path resolution or TopoJSON payload shape is a likely additional cause in deployed environments.
- Improve runtime diagnostics so deployed consoles reveal whether assets are being served from the correct path or returning HTML instead of the expected TopoJSON.

### Description
- Build map asset URLs with `getMapAssetUrl` using `process.env.PUBLIC_URL` so assets work when the app is hosted under a subpath. 
- Add `fetchTopoJson` helper that checks HTTP status, records `content-type`, parses JSON, and validates the expected TopoJSON object key before returning data.
- Emit explicit `console.error` messages (including the URL and error details) when loading `areacode.json` or `digits2.json` fails so deployed DevTools show the root cause. 
- Simplify MapLibre label expressions by replacing the `format`-based `text-field` with a plain `concat` expression and add an explicit empty-string fallback to the 2-digit label `coalesce` to avoid runtime expression-shape issues.

### Testing
- Ran `npx eslint src/areacode/features/map/hooks/useMapGeoData.ts` which passed.
- Previously ran `npx eslint src/areacode/features/map/mapStyles.ts` after the label-expression change which passed.
- Attempted `npm run build` previously which surfaced an unrelated pre-existing module-resolution error and prevented a full production build.
- Started the dev server and used an automated Playwright script to open the local `/areacode/map` page and capture a screenshot to validate the map renders in the development environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f676a0e008329b288748b9d12dd80)