### PR TITLE
Fix deployed map rendering error by stabilizing GeoJSON feature IDs

### DIFF
--- a/src/areacode/features/map/components/MapLayers.tsx
+++ b/src/areacode/features/map/components/MapLayers.tsx
@@ -107,7 +107,6 @@ export function MapLayers({
           id="ma-source"
           type="geojson"
           data={maGeoData}
-          generateId={true}
         >
           <Layer
             {...maFillStyle}
@@ -132,7 +131,6 @@ export function MapLayers({
           id="digits2-source"
           type="geojson"
           data={digits2GeoData}
-          generateId={true}
         >
           <Layer
             {...digits2BorderStyle}


### PR DESCRIPTION
### Motivation
- 本番で MapLibre の GeoJSON ワーカー更新経路が `Error { message: 'n is not defined' }` を出して地図が描画されない問題は、GeoJSON の feature ID が最適化/ワーカー環境で不安定になり `generateId` に依存していたことが原因と推定されたため、アプリ側で安定した ID を付与して対処します。

### Description
- `src/areacode/features/map/hooks/useMapGeoData.ts` に `normalizeGeoJsonFeatures` を追加し、各 feature に `id: feature.id ?? index` を割り当てて `fillColor` を注入するようにしました。 
- `areacode.json` と `digits2.json` の処理をこの正規化関数に置き換え、アプリ側で整形済み GeoJSON を `set*GeoData` に渡すように変更しました。 
- `src/areacode/features/map/components/MapLayers.tsx` の `Source` から `generateId={true}` を削除して、ランタイムでの ID 生成に依存しない構成にしました。 
- 不要な型インポートの簡素化など軽微なクリーンアップを含みます。

### Testing
- `npx eslint src/areacode/features/map/hooks/useMapGeoData.ts src/areacode/features/map/components/MapLayers.tsx` を実行して問題は検出されませんでした。 
- `npm run build` はこのコンテナ環境で `react-map-gl/maplibre` や型/モジュール解決に起因する既存の依存問題のため失敗し、完全なビルド検証は行えませんでした。 
- `npm start` も同様の環境依存エラーで起動できず、ランタイム確認は行えませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f702b39448329af32b79d9db7f998)