### PR TITLE
Precompute MA labels to avoid MapLibre production runtime error

### DIFF
--- a/src/areacode/features/map/hooks/useMapGeoData.ts
+++ b/src/areacode/features/map/hooks/useMapGeoData.ts
@@ -15,6 +15,21 @@ function getFillColor(properties: Record<string, string>): string {
   return getColorStyleByAreaCode(`0${areaCode}`).background.backgroundColor
 }
 
+function normalizeMAPProperties(
+  properties: Record<string, string>,
+): Record<string, string> {
+  const areaCode = properties['_市外局番'] ?? ''
+  const maName = properties['_MA名'] ?? ''
+
+  return {
+    ...properties,
+    areaCode,
+    maName,
+    maLabel: areaCode ? `0${areaCode}\n${maName}` : maName,
+    fillColor: getFillColor(properties),
+  }
+}
+
 function getMapAssetUrl(filename: string): string {
   const base = (process.env.PUBLIC_URL ?? '').replace(/\/$/, '')
   return `${base}/map/${filename}`
@@ -64,10 +79,7 @@ export function useMapGeoData() {
           const properties = (f.properties ?? {}) as Record<string, string>
           return {
             ...f,
-            properties: {
-              ...properties,
-              fillColor: getFillColor(properties),
-            },
+            properties: normalizeMAPProperties(properties),
           }
         })
         setMaGeoData(geojson)
@@ -90,10 +102,7 @@ export function useMapGeoData() {
           const properties = (f.properties ?? {}) as Record<string, string>
           return {
             ...f,
-            properties: {
-              ...properties,
-              fillColor: getFillColor(properties),
-            },
+            properties: normalizeMAPProperties(properties),
           }
         })
         setDigits2GeoData(geojson)

--- a/src/areacode/features/map/mapStyles.ts
+++ b/src/areacode/features/map/mapStyles.ts
@@ -62,13 +62,7 @@ export const maLabelStyle: SymbolLayerSpecification = {
   id: 'ma-labels',
   type: 'symbol',
   layout: {
-    'text-field': [
-      'concat',
-      '0',
-      ['coalesce', ['get', '_市外局番'], ''],
-      '\n',
-      ['coalesce', ['get', '_MA名'], ''],
-    ],
+    'text-field': ['coalesce', ['get', 'maLabel'], ''],
     'text-size': ['interpolate', ['linear'], ['zoom'], 5, 11, 8, 14],
     'text-font': [...JAPANESE_LABEL_FONT_STACK],
     'text-anchor': 'center',


### PR DESCRIPTION
### Motivation
- The deployed map failed with `Error: n is not defined` during MapLibre GeoJSON worker/style evaluation when building/serving the site, causing maps not to render. 
- The root cause appears to be a runtime/minified evaluation of a complex `text-field` `concat` expression in the MapLibre style that can fail under production/minified execution. 

### Description
- Replace the runtime `concat` expression for MA labels with a precomputed property by adding `maLabel` on each feature so the style reads plain text instead of evaluating an expression. (`src/areacode/features/map/hooks/useMapGeoData.ts`) 
- Add `normalizeMAPProperties` to compute and normalize feature properties including `maLabel` and `fillColor`, and use it for both MA and 2-digit GeoJSON loads. (`src/areacode/features/map/hooks/useMapGeoData.ts`) 
- Update the MA label layer to use `['coalesce', ['get', 'maLabel'], '']` instead of the previous `concat` expression. (`src/areacode/features/map/mapStyles.ts`) 

### Testing
- Attempted a production build with `npm run build`, but the environment failed because `react-scripts` was not available in the container (`sh: 1: react-scripts: not found`), so a full build verification could not be completed. 
- Package install attempts (`npm ci` / `npm install`) were run in the container to prepare build tooling but the registry/install environment prevented completing a full build verification; no automated unit tests were present or run for these files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f702b39448329af32b79d9db7f998)