### PR TITLE
都道府県ラベルを地図に追加し、クリックで右パネル選択と連携

### DIFF
--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -527,6 +527,7 @@ function App() {
             showPref={showPref}
             showCity={showCity}
             zoom={mapZoom}
+            onPrefLabelClick={handlePrefSelect}
           />
         </MapView>
       </div>

--- a/src/areacode/features/map/map.css
+++ b/src/areacode/features/map/map.css
@@ -188,3 +188,23 @@
   font-weight: 700;
   line-height: 1;
 }
+
+.pref-map-label-marker {
+  border: none;
+  border-radius: 9999px;
+  background: #16a34a;
+  color: #ffffff;
+  font-family: 'Roboto', 'Noto Sans JP', sans-serif;
+  font-weight: 700;
+  font-size: 12px;
+  line-height: 1;
+  padding: 8px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.28);
+  transition: opacity 0.15s ease;
+}
+
+.pref-map-label-marker:hover {
+  opacity: 0.78;
+}


### PR DESCRIPTION
### Motivation
- 地図上の都道府県レイヤに都道府県名ラベルを常時表示し、右の選択パネルで都道府県を選んだときと同じ挙動でラベルから選択できるようにするため。
- ラベルは視認性を確保するため緑色の丸ボックス＋白文字で表示し、ホバーで少し透明になるUIにするため。

### Description
- `src/areacode/features/map/components/MapLayers.tsx` に都道府県GeoJSONからラベル用マーカーを生成する `prefLabelMarkers` を追加し、`showPref` 時に `Marker` として描画するようにしました。 
- ラベルのクリックを処理するために `MapLayers` の props に `onPrefLabelClick: (prefName: string) => void` を追加し、ボタンの `onClick` で `event.stopPropagation()` の上で呼び出すようにしました。 
- 親コンポーネント `src/areacode/features/map/index.tsx` で既存の都道府県選択ハンドラ `handlePrefSelect` を `MapLayers` の `onPrefLabelClick` に渡すように変更し、ラベルクリックで右パネル選択と同じ処理が走るように接続しました。 
- 見た目を調整するため `src/areacode/features/map/map.css` に `.pref-map-label-marker` とホバー時のスタイルを追加し、緑の丸ボックス・白文字・ホバーで透明化する仕様を実装しました。 

### Testing
- `npx prettier --write` を実行して該当ファイルの整形を行いました（成功）。
- `npm run build` を実行してビルドを確認し、ビルドは成功しましたが既存の ESLint 警告は継続して表示されました（変更によるエラーは無し）。
- 自動化スクリプトで開発サーバー上の `/areacode/map` を読み込みスクリーンショットを取得して、ラベルが表示されることとクリックで `handlePrefSelect` 相当の処理につながることを目視で確認しました（Playwright スクリプトで取得したスクリーンショットあり）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f52406e08329afcb01ad15a3c369)