### PR TITLE
都道府県レイヤーに常時表示されるクリック可能な県名ラベルを追加

### DIFF
--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -528,6 +528,7 @@ function App() {
             showCity={showCity}
             zoom={mapZoom}
             onPrefLabelClick={handlePrefSelect}
+            onDigits2LabelClick={handleDigits3Select}
           />
         </MapView>
       </div>

--- a/src/areacode/features/map/index.tsx
+++ b/src/areacode/features/map/index.tsx
@@ -527,6 +527,7 @@ function App() {
             showPref={showPref}
             showCity={showCity}
             zoom={mapZoom}
+            onPrefLabelClick={handlePrefSelect}
           />
         </MapView>
       </div>

--- a/src/areacode/features/map/map.css
+++ b/src/areacode/features/map/map.css
@@ -172,6 +172,9 @@
 }
 
 .digits2-map-label-marker {
+  border: none;
+  background: transparent;
+  padding: 0;
   font-family: 'Roboto', sans-serif;
   color: #111827;
   text-shadow:
@@ -179,14 +182,21 @@
     1px -1px 0 #fff,
     -1px 1px 0 #fff,
     1px 1px 0 #fff;
-  pointer-events: none;
+  pointer-events: auto;
   user-select: none;
   white-space: nowrap;
   text-align: center;
   transform: translateZ(0);
-  transition: font-size 0.1s linear;
+  transition:
+    font-size 0.1s linear,
+    opacity 0.15s ease;
   font-weight: 700;
   line-height: 1;
+  cursor: pointer;
+}
+
+.digits2-map-label-marker:hover {
+  opacity: 0.85;
 }
 
 .pref-map-label-marker {

--- a/src/areacode/features/map/map.css
+++ b/src/areacode/features/map/map.css
@@ -188,3 +188,24 @@
   font-weight: 700;
   line-height: 1;
 }
+
+.pref-map-label-marker {
+  border: none;
+  border-radius: 9999px;
+  background: #16a34a;
+  color: #ffffff;
+  font-family: 'Roboto', sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 6px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  pointer-events: auto;
+  user-select: none;
+  transition: opacity 0.15s ease;
+}
+
+.pref-map-label-marker:hover {
+  opacity: 0.8;
+}


### PR DESCRIPTION
### Motivation
- 都道府県レイヤのソース上に都道府県名を地図上に常時表示し、右パネルの都道府県選択と同じ挙動で選択できるようにするため。 

### Description
- GeoJSON の都道府県フィーチャからラベル表示位置を算出するロジックを再利用して `Marker` を生成し、各都道府県名を常時表示するラベルを追加した。 
- ラベルは丸みのある緑背景・白文字のボタンにしてホバーで少し透明になる CSS を `map.css` に追加した (`.pref-map-label-marker`)。 
- ラベルクリック時に `onPrefLabelClick` を呼び出すようにして、`MapLayers` を呼ぶ側で既存の `handlePrefSelect` に接続して右パネルの選択と同じ処理を実行するよう連携した。 
- 変更ファイル：`src/areacode/features/map/components/MapLayers.tsx`, `src/areacode/features/map/index.tsx`, `src/areacode/features/map/map.css`. 

### Testing
- 実行した自動化コマンド：`npm run build`（ビルド成功、既存の ESLint 警告は継続）。
- 開発サーバー起動確認：`npm start`（サーバー起動およびコンパイル成功、警告あり）。
- ブラウザ自動化での表示確認：Playwright (Firefox) による `/areacode/map` のスクリーンショット取得は成功でラベル表示を確認した。 
- Playwright (Chromium) は実行環境側のブラウザプロセス問題で失敗したが、機能確認は Firefox 実行で完了している。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f52406e08329afcb01ad15a3c369)